### PR TITLE
Add LandShare Mainnet to  defactor-pools.json

### DIFF
--- a/static/mainnet/defactor-pools.json
+++ b/static/mainnet/defactor-pools.json
@@ -70,7 +70,7 @@
         "type": "Erc20 Collateral Pool",
         "contract": "0x6cbA45B0228F7e2e058e877060619225F9979c87",
         "token": "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d",
-        "oracle": "0x60E87395b0101F85C623c38Be010574f958496db",
+        "oracle": "0xd2896dE7De086BFcd80B66356458Ae61BE4aBEaD",
         "collateral": [
           "0xa73164db271931cf952cbaeff9e8f5817b42fa5c",
           "0x475ed67bfc62b41c048b81310337c1d75d45aadd"

--- a/static/mainnet/defactor-pools.json
+++ b/static/mainnet/defactor-pools.json
@@ -57,5 +57,25 @@
         "collateral": "0x6fC27F5CC0aAFeC8e2b8bC4E6393aC89e45232d3"
       }
     ]
+  },
+  {
+    "id": "pools-landshare-mainnet",
+    "name": "LandShare Production",
+    "description": "Production environment for LandShare.",
+    "web": "https://landshare.factr.app",
+    "api": "https://landshare-api.factr.app",
+    "chains": [
+      {
+        "id": "Bsc",
+        "type": "Erc20 Collateral Pool",
+        "contract": "0x6cbA45B0228F7e2e058e877060619225F9979c87",
+        "token": "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d",
+        "oracle": "0x60E87395b0101F85C623c38Be010574f958496db",
+        "collateral": [
+          "0xa73164db271931cf952cbaeff9e8f5817b42fa5c",
+          "0x475ed67bfc62b41c048b81310337c1d75d45aadd"
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
### Add LandShare Mainnet to  defactor-pools.json

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add LandShare Mainnet configuration to `defactor-pools.json`.

### Why are these changes being made?

This change introduces the LandShare Production environment to the mainnet configuration, enabling support for its ERC20 collateral pool on the Binance Smart Chain (BSC). This addition is necessary to integrate LandShare's production environment into the existing infrastructure, allowing for seamless interaction and management of its assets.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->